### PR TITLE
fix(recipes): if you can't parse the time, return 0 timedelta

### DIFF
--- a/recipes/extrators.py
+++ b/recipes/extrators.py
@@ -38,8 +38,11 @@ def get_isosplit(s, split):
     return n, s
 
 
-def parse_isoduration(s):
-    s = s.split("P")[-1]
+def parse_isoduration(s: str) -> timedelta:
+    try:
+        s = s.split("P")[-1]
+    except (IndexError, AttributeError):
+        return timedelta()
 
     days, s = get_isosplit(s, "D")
     _, s = get_isosplit(s, "T")


### PR DESCRIPTION
Fixes #575

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix parsing of ISO duration strings to return a zero timedelta when the input is invalid, addressing issue #575.

Bug Fixes:
- Return a zero timedelta when parsing an invalid ISO duration string to prevent errors.

<!-- Generated by sourcery-ai[bot]: end summary -->