### PR TITLE
fix(books): set the owner on create

### DIFF
--- a/books/api.py
+++ b/books/api.py
@@ -55,5 +55,8 @@ class SyncSettingsViewSet(viewsets.ModelViewSet):
     serializer_class = serializers.SyncSettingSerializer
     permission_classes = [permissions.IsAuthenticated, IsOwner]
 
+    def perform_create(self, serializer):
+        serializer.save(owner=self.request.user)
+
     def get_queryset(self):
         return models.SyncSetting.objects.authorize(self.request, action="retrieve")


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the issue where the owner was not being set on the creation of a SyncSetting instance by assigning the current user as the owner in the perform_create method.

Bug Fixes:
- Ensure the owner is set when creating a new SyncSetting instance by assigning the current user as the owner during the creation process.

<!-- Generated by sourcery-ai[bot]: end summary -->