### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,18 +1,24 @@
 pull_request_rules:
-- name: Merge Mine
-  conditions:
-  - and:
-    - author~=^bengosney$
-    - check-success=workflow
-    - label=automerge
-  actions:
-    merge:
-      method: merge
-
-- name: Automatic merge dependabot PR
-  conditions:
-  - author~=^dependabot(|-preview)\[bot\]$
-  - check-success=workflow
-  actions:
-    merge:
-      method: merge
+  - name: Merge Updates
+    conditions:
+      - and:
+          - author~=^github-actions
+          - title~=^Update
+    actions:
+      merge:
+        method: merge
+  - name: Merge Mine
+    conditions:
+      - and:
+          - author~=^bengosney$
+          - "#approved-reviews-by > 0"
+          - "#review-threads-unresolved = 0"
+    actions:
+      merge:
+        method: merge
+  - name: Automatic merge dependabot PR
+    conditions:
+      - author~=^dependabot(|-preview)\[bot\]$
+    actions:
+      merge:
+        method: merge


### PR DESCRIPTION
This change has been made by @bengosney from the Mergify config editor.

## Summary by Sourcery

Update Mergify configuration to add a new auto-merge rule for GitHub Actions updates, tighten approval requirements for user-authored PRs, and simplify the Dependabot rule by removing status check conditions.

CI:
- Add “Merge Updates” rule to auto-merge PRs from github-actions with titles starting “Update”.
- Require at least one approved review and no unresolved threads for the “Merge Mine” rule instead of status checks and labels.
- Remove the workflow success condition from the Dependabot auto-merge rule.