### PR TITLE
feat: add step to fix known_hosts for git.flaminghedgehog.com in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,6 +13,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fix known_hosts for git.flaminghedgehog.com
+        run: |
+          ssh-keygen -R git.flaminghedgehog.com -f ~/.ssh/known_hosts || true
+          ssh-keyscan git.flaminghedgehog.com >> ~/.ssh/known_hosts
+
       - name: Push to dokku
         uses: dokku/github-action@master
         with:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add step to remove and re-add git.flaminghedgehog.com host key in deploy workflow