### PR TITLE
fix: simplify known_hosts handling in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,8 +15,7 @@ jobs:
 
       - name: Fix known_hosts for git.flaminghedgehog.com
         run: |
-          ssh-keygen -R git.flaminghedgehog.com -f ~/.ssh/known_hosts || true
-          ssh-keyscan git.flaminghedgehog.com >> ~/.ssh/known_hosts
+          ssh-keygen -R git.flaminghedgehog.com || true
 
       - name: Push to dokku
         uses: dokku/github-action@master


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Replace explicit known_hosts removal and re-addition with a single ssh-keygen -R command