### PR TITLE
fix: comment out unused ssh_host_key in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,6 +21,6 @@ jobs:
         uses: dokku/github-action@master
         with:
           branch: 'main'
-          ssh_host_key: ${{ secrets.SSH_HOST_KEY }}
+          # ssh_host_key: ${{ secrets.SSH_HOST_KEY }}
           git_remote_url: ${{ secrets.SSH_HOST_URL }}
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Comment out the unused ssh_host_key parameter in the deploy workflow