### PR TITLE
fix: remove unused ssh_host_key from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,6 +21,5 @@ jobs:
         uses: dokku/github-action@master
         with:
           branch: 'main'
-          # ssh_host_key: ${{ secrets.SSH_HOST_KEY }}
           git_remote_url: ${{ secrets.SSH_HOST_URL }}
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Remove unused `ssh_host_key` input from the deploy workflow.