### PR TITLE
fix: add rest_framework_simplejwt.token_blacklist to installed apps

### DIFF
--- a/isitbinday/settings/base.py
+++ b/isitbinday/settings/base.py
@@ -31,6 +31,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "django_extensions",
     "rest_framework",
+    "rest_framework_simplejwt.token_blacklist",
     "corsheaders",
     "adminsortable2",
     "django_fsm",


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Include rest_framework_simplejwt.token_blacklist in INSTALLED_APPS to fix missing blacklist configuration.